### PR TITLE
setting location to transient

### DIFF
--- a/app/src/main/java/com/example/trialio/models/Location.java
+++ b/app/src/main/java/com/example/trialio/models/Location.java
@@ -43,7 +43,7 @@ public class Location implements Serializable{
     private double longitude;
 
     final int REQUEST_CODE_FINE_PERMISSION = 99;
-    FusedLocationProviderClient locClient;
+    transient FusedLocationProviderClient locClient;
 
 
     public Location() {


### PR DESCRIPTION
The location provider client is not serializable, and hence will cause error is you click view trials after uploading a trial, applied the transient property to it