### PR TITLE
Fixed bug where changing username broke the CurrentUserHandler

### DIFF
--- a/app/src/main/java/com/example/trialio/controllers/ChangeUsernameCommand.java
+++ b/app/src/main/java/com/example/trialio/controllers/ChangeUsernameCommand.java
@@ -37,6 +37,7 @@ public class ChangeUsernameCommand {
             @Override
             public void onSuccess(Void aVoid) {
                 // Username change was successful
+                CurrentUserHandler.getInstance().refresh();
                 listener.onResult(true);
             }
         }).addOnFailureListener(new OnFailureListener() {

--- a/app/src/main/java/com/example/trialio/controllers/CurrentUserHandler.java
+++ b/app/src/main/java/com/example/trialio/controllers/CurrentUserHandler.java
@@ -27,7 +27,7 @@ public class CurrentUserHandler {
     /**
      * The singleton instance that is initialized on startup
      */
-    private static final CurrentUserHandler instance = new CurrentUserHandler();
+    private static CurrentUserHandler instance = new CurrentUserHandler();
 
     /**
      * The current user for the application instance
@@ -89,6 +89,13 @@ public class CurrentUserHandler {
      */
     public static CurrentUserHandler getInstance() {
         return instance;
+    }
+
+    /**
+     * Forces the CurrentUserHandler to fetch the current user again from scratch
+     */
+    public void refresh() {
+        instance = new CurrentUserHandler();
     }
 
     /**


### PR DESCRIPTION
Changing the username of a user would break the reference between the user handler and the database document. Fixed this issue so it works as expected