### PR TITLE
Upgrades to QR code scanning and added user friendly changes

### DIFF
--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -116,38 +116,41 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
         Log.d(TAG, "Process scanned result: isBarcode = " + isBarcode.toString());
         String[] items = text.split("\n");
         Log.d(TAG, "Raw Input: " + Arrays.toString(items));
-        // it reads in from which activity is scanning activity called from
-        // if ExperimentActivity is calling Scanning activity, it means user wants to scan a QR or a barcode
-        // if its not experiment activity it means user is trying to register a barcode
+        /*
+         * reads in from which activity is scanning activity called from
+         * if ExperimentActivity is calling Scanning activity, it means user wants to scan a QR or a barcode
+         * if its not experiment activity it means user is trying to register a barcode
+         */
+
         if (parentActivity.equals("ExperimentActivity")) {
+            // user wants to scan code to record trial
 //            Log.d(TAG, String.valueOf(items.length));
             if (String.valueOf(items.length).equals("3")) {
                 // user is scanning a QR code to add trial
                 Log.d(TAG, "QR Code identified");
-                QRCodeGenerator.readQR(getApplicationContext(), items, null, null);
-//                if (experiment.getSettings().getGeoLocationRequired()) {
-//                    Task<android.location.Location> locTask = Location.requestLocation(context);
-//                    if (locTask == null) {
-//                        displayNoLocationToast();
-//                        return;
-//                    }
-//                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
-//                        @Override
-//                        public void onSuccess(android.location.Location loc) {
-//                            Location location = new Location();
-//                            location.setLatitude(loc.getLatitude());
-//                            location.setLongitude(loc.getLongitude());
-//                            QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
-//                        }
-//                    });
-//                } else {
-//                    Location location = new Location();
-//                    QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
-//                }
-                // if its a Barcode
+                QRCodeGenerator.readQR(getApplicationContext(), items, new QRCodeGenerator.OnReadResultListener() {
+                    @Override
+                    public void onReadResult(QRCodeGenerator.Result result) {
+                        switch(result) {
+                            case SUCCESS:
+                                displaySuccessToast();
+                                break;
+
+                            case EXPERIMENT_CLOSED:
+                                displayExperimentClosedToast();
+                                break;
+
+                            case LOCATION_DENIED:
+                                displayNoLocationToast();
+                                break;
+                        }
+                    }
+                });
+
             } else {
                 // user is scanning a barcode to add trial
                 Log.d(TAG, "Barcode identified");
+
                 if (experiment.getSettings().getGeoLocationRequired()) {
                     Task<android.location.Location> locTask = Location.requestLocation(context);
                     if (locTask == null) {

--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -131,7 +131,7 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                 QRCodeGenerator.readQR(getApplicationContext(), items, new QRCodeGenerator.OnReadResultListener() {
                     @Override
                     public void onReadResult(QRCodeGenerator.Result result) {
-                        switch(result) {
+                        switch (result) {
                             case SUCCESS:
                                 displaySuccessToast();
                                 break;
@@ -143,6 +143,10 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                             case LOCATION_DENIED:
                                 displayNoLocationToast();
                                 break;
+
+                            case INVALID_EXPERIMENT:
+                                displayInvalidExperimentToast();
+                                break;
                         }
                     }
                 });
@@ -150,28 +154,55 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
             } else {
                 // user is scanning a barcode to add trial
                 Log.d(TAG, "Barcode identified");
+                barcodeManager = new BarcodeManager(currentUser.getUsername());
+                barcodeManager.readBarcode(getApplicationContext(), text, null, null, new BarcodeManager.OnReadResultListener() {
+                    @Override
+                    public void onReadResult(BarcodeManager.Result result) {
+                        switch (result) {
+                            case SUCCESS:
+                                displaySuccessToast();
+                                break;
 
-                if (experiment.getSettings().getGeoLocationRequired()) {
-                    Task<android.location.Location> locTask = Location.requestLocation(context);
-                    if (locTask == null) {
-                        displayNoLocationToast();
-                        return;
-                    }
-                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
-                        @Override
-                        public void onSuccess(android.location.Location loc) {
-                            Location location = new Location();
-                            location.setLatitude(loc.getLatitude());
-                            location.setLongitude(loc.getLongitude());
-                            barcodeManager = new BarcodeManager(currentUser.getUsername());
-                            barcodeManager.readBarcode(text, location, currentUser);
+                            case EXPERIMENT_CLOSED:
+                                displayExperimentClosedToast();
+                                break;
+
+                            case LOCATION_DENIED:
+                                displayNoLocationToast();
+                                break;
+
+                            case INVALID_EXPERIMENT:
+                                displayInvalidExperimentToast();
+                                break;
+
+                            case UNREGISTERED_BARCODE:
+                                displayUnRegBarcodeToast();
+                                break;
                         }
-                    });
-                } else {
-                    Location location = new Location();
-                    barcodeManager = new BarcodeManager(currentUser.getUsername());
-                    barcodeManager.readBarcode(text, location, currentUser);
-                }
+                    }
+                });
+
+//                if (experiment.getSettings().getGeoLocationRequired()) {
+//                    Task<android.location.Location> locTask = Location.requestLocation(context);
+//                    if (locTask == null) {
+//                        displayNoLocationToast();
+//                        return;
+//                    }
+//                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
+//                        @Override
+//                        public void onSuccess(android.location.Location loc) {
+//                            Location location = new Location();
+//                            location.setLatitude(loc.getLatitude());
+//                            location.setLongitude(loc.getLongitude());
+//                            barcodeManager = new BarcodeManager(currentUser.getUsername());
+////                            barcodeManager.readBarcode(text, location, currentUser);
+//                        }
+//                    });
+//                } else {
+//                    Location location = new Location();
+//                    barcodeManager = new BarcodeManager(currentUser.getUsername());
+////                    barcodeManager.readBarcode(text, location, currentUser);
+//                }
             }
             // if intent is not coming from Experiment Activity i.e. QRActivity
             // this is used for registering new barcode
@@ -223,6 +254,24 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
      */
     private void displaySuccessToast() {
         String message = "Trial added successfully";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    /**
+     * Displays message when invalid experiment was provided and no trial could be added
+     */
+    private void displayInvalidExperimentToast() {
+        String message = "Unable to add trial: This experiment does not exist";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    /**
+     * Displays a message when the user scans an unregistered barcode
+     */
+    private void displayUnRegBarcodeToast() {
+        String message = "Unable to add trial: This barcode has not been registered";
         Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
         toast.show();
     }

--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -126,6 +126,7 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                 if (experiment.getSettings().getGeoLocationRequired()) {
                     Task<android.location.Location> locTask = Location.requestLocation(context);
                     if (locTask == null) {
+                        displayNoLocationToast();
                         return;
                     }
                     locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
@@ -137,15 +138,16 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                             QRCodeGenerator.readQR(items, location, currentUser);
                         }
                     });
-                }else{
+                } else {
                     Location location = new Location();
                     QRCodeGenerator.readQR(items, location, currentUser);
                 }
-            // if its a Barcode
+                // if its a Barcode
             } else {
                 if (experiment.getSettings().getGeoLocationRequired()) {
                     Task<android.location.Location> locTask = Location.requestLocation(context);
                     if (locTask == null) {
+                        displayNoLocationToast();
                         return;
                     }
                     locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
@@ -158,7 +160,7 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                             barcodeManager.readBarcode(processed, location, currentUser);
                         }
                     });
-                }else {
+                } else {
                     Location location = new Location();
                     barcodeManager = new BarcodeManager(currentUser.getUsername());
                     barcodeManager.readBarcode(processed, location, currentUser);
@@ -167,25 +169,45 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
             // if intent is not coming from Experiment Activity i.e. QRActivity
             // this is used for registering new barcode
         } else {
-            // if user try to register a QR Code
-            if (String.valueOf(items.length).equals("3")){
-                //Source:
-                //Toast Overview from Android Documentations
-                //https://developer.android.com/guide/topics/ui/notifiers/toasts
-                Context context = getApplicationContext();
-                CharSequence toastMessage = "Please do not register a QRCode as a barcode.";
-                int duration = Toast.LENGTH_SHORT;
-
-                Toast toast = Toast.makeText(context, toastMessage, duration);
-                toast.show();
-            // register barcode
-            }else{
+            if (String.valueOf(items.length).equals("3")) {
+                // user tried to register a QR Code
+                displayRegisterQRCodeAsBarcodeToast();
+            } else {
+                // register the barcode
                 barcodeManager = new BarcodeManager(currentUser.getUsername());
                 barcodeManager.registerBarcode(text, experiment, result);
             }
         }
 
 
+    }
+
+    /**
+     * Displays error message to the user cannot register a QR Code as a custom barcode
+     */
+    private void displayRegisterQRCodeAsBarcodeToast() {
+        String message = "Please do not register a QR code as a barcode";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    /**
+     * Displays error message to the user that trial could not be added because location services
+     * are not enabled
+     */
+    private void displayNoLocationToast() {
+        String message = "Unable to add trial: Please enable location permissions";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    /**
+     * Displays message to user when trial was added successfully.
+     */
+    private void displaySuccessToast() {
+        String message = "Trial added successfully";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
     }
 }
 

--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -46,7 +46,7 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
     private String parentActivity;
     private Context context = this;
 
-    private final String TAG = "scanningactivity";
+    private final String TAG = "ScanningActivity";
 
 
     /**
@@ -111,16 +111,14 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
      * @param text
      */
     private void processResult(String text) {
-        Log.d(TAG, "in ProcessResult");
-        Log.d(TAG, String.valueOf(isBarcode));
-        String processed = text;
-        String[] items = processed.split("\n");
+        Log.d(TAG, "Process scanned result: isBarcode = " + isBarcode.toString());
+        String[] items = text.split("\n");
+        Log.d(TAG, "Raw Input: " + items);
         // it reads in from which activity is scanning activity called from
         // if ExperimentActivity is calling Scanning activity, it means user wants to scan a QR or a barcode
         // if its not experiment activity it means user is trying to register a barcode
         if (parentActivity.equals("ExperimentActivity")) {
             Log.d(TAG, String.valueOf(items.length));
-            Log.d(TAG, processed);
             // if its a QRCode the length is 3
             if (String.valueOf(items.length).equals("3")) {
                 if (experiment.getSettings().getGeoLocationRequired()) {
@@ -135,12 +133,12 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                             Location location = new Location();
                             location.setLatitude(loc.getLatitude());
                             location.setLongitude(loc.getLongitude());
-                            QRCodeGenerator.readQR(items, location, currentUser);
+                            QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
                         }
                     });
                 } else {
                     Location location = new Location();
-                    QRCodeGenerator.readQR(items, location, currentUser);
+                    QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
                 }
                 // if its a Barcode
             } else {
@@ -157,13 +155,13 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                             location.setLatitude(loc.getLatitude());
                             location.setLongitude(loc.getLongitude());
                             barcodeManager = new BarcodeManager(currentUser.getUsername());
-                            barcodeManager.readBarcode(processed, location, currentUser);
+                            barcodeManager.readBarcode(text, location, currentUser);
                         }
                     });
                 } else {
                     Location location = new Location();
                     barcodeManager = new BarcodeManager(currentUser.getUsername());
-                    barcodeManager.readBarcode(processed, location, currentUser);
+                    barcodeManager.readBarcode(text, location, currentUser);
                 }
             }
             // if intent is not coming from Experiment Activity i.e. QRActivity
@@ -197,6 +195,16 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
      */
     private void displayNoLocationToast() {
         String message = "Unable to add trial: Please enable location permissions";
+        Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    /**
+     * Displays error message to the user that trial could not be added because location services
+     * are not enabled
+     */
+    private void displayExperimentClosedToast() {
+        String message = "Unable to add trial: This experiment is closed to new trials";
         Toast toast = Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG);
         toast.show();
     }

--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -121,11 +121,12 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
          * if ExperimentActivity is calling Scanning activity, it means user wants to scan a QR or a barcode
          * if its not experiment activity it means user is trying to register a barcode
          */
+        boolean isQR = String.valueOf(items.length).equals("3"); // otherwise it's barcode
+        boolean isAddTrial = parentActivity.equals("ExperimentActivity"); // otherwise it's register (barcode)
 
-        if (parentActivity.equals("ExperimentActivity")) {
+        if (isAddTrial) {
             // user wants to scan code to record trial
-//            Log.d(TAG, String.valueOf(items.length));
-            if (String.valueOf(items.length).equals("3")) {
+            if (isQR) {
                 // user is scanning a QR code to add trial
                 Log.d(TAG, "QR Code identified");
                 QRCodeGenerator.readQR(getApplicationContext(), items, new QRCodeGenerator.OnReadResultListener() {
@@ -155,7 +156,7 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                 // user is scanning a barcode to add trial
                 Log.d(TAG, "Barcode identified");
                 barcodeManager = new BarcodeManager(currentUser.getUsername());
-                barcodeManager.readBarcode(getApplicationContext(), text, null, null, new BarcodeManager.OnReadResultListener() {
+                barcodeManager.readBarcode(getApplicationContext(), text, new BarcodeManager.OnReadResultListener() {
                     @Override
                     public void onReadResult(BarcodeManager.Result result) {
                         switch (result) {
@@ -181,33 +182,11 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
                         }
                     }
                 });
-
-//                if (experiment.getSettings().getGeoLocationRequired()) {
-//                    Task<android.location.Location> locTask = Location.requestLocation(context);
-//                    if (locTask == null) {
-//                        displayNoLocationToast();
-//                        return;
-//                    }
-//                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
-//                        @Override
-//                        public void onSuccess(android.location.Location loc) {
-//                            Location location = new Location();
-//                            location.setLatitude(loc.getLatitude());
-//                            location.setLongitude(loc.getLongitude());
-//                            barcodeManager = new BarcodeManager(currentUser.getUsername());
-////                            barcodeManager.readBarcode(text, location, currentUser);
-//                        }
-//                    });
-//                } else {
-//                    Location location = new Location();
-//                    barcodeManager = new BarcodeManager(currentUser.getUsername());
-////                    barcodeManager.readBarcode(text, location, currentUser);
-//                }
             }
+        } else {
             // if intent is not coming from Experiment Activity i.e. QRActivity
             // this is used for registering new barcode
-        } else {
-            if (String.valueOf(items.length).equals("3")) {
+            if (isQR) {
                 // user tried to register a QR Code
                 displayRegisterQRCodeAsBarcodeToast();
             } else {

--- a/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
+++ b/app/src/main/java/com/example/trialio/activities/ScanningActivity.java
@@ -30,6 +30,8 @@ import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.PermissionRequest;
 import com.karumi.dexter.listener.single.PermissionListener;
 
+import java.util.Arrays;
+
 import me.dm7.barcodescanner.zxing.ZXingScannerView;
 
 
@@ -113,35 +115,39 @@ public class ScanningActivity extends AppCompatActivity implements ZXingScannerV
     private void processResult(String text) {
         Log.d(TAG, "Process scanned result: isBarcode = " + isBarcode.toString());
         String[] items = text.split("\n");
-        Log.d(TAG, "Raw Input: " + items);
+        Log.d(TAG, "Raw Input: " + Arrays.toString(items));
         // it reads in from which activity is scanning activity called from
         // if ExperimentActivity is calling Scanning activity, it means user wants to scan a QR or a barcode
         // if its not experiment activity it means user is trying to register a barcode
         if (parentActivity.equals("ExperimentActivity")) {
-            Log.d(TAG, String.valueOf(items.length));
-            // if its a QRCode the length is 3
+//            Log.d(TAG, String.valueOf(items.length));
             if (String.valueOf(items.length).equals("3")) {
-                if (experiment.getSettings().getGeoLocationRequired()) {
-                    Task<android.location.Location> locTask = Location.requestLocation(context);
-                    if (locTask == null) {
-                        displayNoLocationToast();
-                        return;
-                    }
-                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
-                        @Override
-                        public void onSuccess(android.location.Location loc) {
-                            Location location = new Location();
-                            location.setLatitude(loc.getLatitude());
-                            location.setLongitude(loc.getLongitude());
-                            QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
-                        }
-                    });
-                } else {
-                    Location location = new Location();
-                    QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
-                }
+                // user is scanning a QR code to add trial
+                Log.d(TAG, "QR Code identified");
+                QRCodeGenerator.readQR(getApplicationContext(), items, null, null);
+//                if (experiment.getSettings().getGeoLocationRequired()) {
+//                    Task<android.location.Location> locTask = Location.requestLocation(context);
+//                    if (locTask == null) {
+//                        displayNoLocationToast();
+//                        return;
+//                    }
+//                    locTask.addOnSuccessListener(new OnSuccessListener<android.location.Location>() {
+//                        @Override
+//                        public void onSuccess(android.location.Location loc) {
+//                            Location location = new Location();
+//                            location.setLatitude(loc.getLatitude());
+//                            location.setLongitude(loc.getLongitude());
+//                            QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
+//                        }
+//                    });
+//                } else {
+//                    Location location = new Location();
+//                    QRCodeGenerator.readQR(getApplicationContext(), items, location, currentUser);
+//                }
                 // if its a Barcode
             } else {
+                // user is scanning a barcode to add trial
+                Log.d(TAG, "Barcode identified");
                 if (experiment.getSettings().getGeoLocationRequired()) {
                     Task<android.location.Location> locTask = Location.requestLocation(context);
                     if (locTask == null) {

--- a/app/src/main/java/com/example/trialio/controllers/BarcodeManager.java
+++ b/app/src/main/java/com/example/trialio/controllers/BarcodeManager.java
@@ -275,12 +275,12 @@ public class BarcodeManager implements Serializable {
     /**
      * readBarcode reads registered barcode and add a new trial to its responsible experiment
      *
-     * @param input
-     * @param location
-     * @param user
+     * @param context  the context in which the barcode was scanned
+     * @param input    the raw input of the scanned barcode
+     * @param listener the listener callback to pass the result of the read
      */
     //input contains barcode info, use the info to fetch the document from firebase
-    public void readBarcode(Context context, String input, Location location, User user, OnReadResultListener listener) {
+    public void readBarcode(Context context, String input, OnReadResultListener listener) {
         setOnBarcodeFetchListener(input, new OnBarcodeFetchListener() {
             @Override
             public void onBarcodeFetch(Barcode barcode) {
@@ -345,59 +345,22 @@ public class BarcodeManager implements Serializable {
 
                     }
                 });
-//
-//                Date date = new Date();
-//                if (type.equals("BINOMIAL")) {
-//                    Log.d(TAG, "in Binomial");
-//                    Log.d(TAG, experiment.getExperimentID());
-//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-//                        @Override
-//                        public void onExperimentFetch(Experiment new_experiment) {
-//                            Log.d(TAG, new_experiment.getExperimentID());
-//                            BinomialTrial new_trial = new BinomialTrial(user.getId(), location, date, Boolean.parseBoolean(barcode.getTrialResult()));
-//                            Log.d(TAG, " Binomial trial created");
-//                            new_experiment.getTrialManager().addTrial(new_trial);
-//                            Log.d(TAG, " Binomial trial added");
-//
-//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-//                        }
-//                    });
-//                } else if (type.equals("COUNT")) {
-//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-//                        @Override
-//                        public void onExperimentFetch(Experiment new_experiment) {
-//                            CountTrial new_trial = new CountTrial(user.getId(), location, date);
-//                            new_experiment.getTrialManager().addTrial(new_trial);
-//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-//                        }
-//                    });
-//                } else if (type.equals("NONNEGATIVE")) {
-//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-//                        @Override
-//                        public void onExperimentFetch(Experiment new_experiment) {
-//                            NonNegativeTrial new_trial = new NonNegativeTrial(user.getId(), location, date, Integer.parseInt(barcode.getTrialResult()));
-//                            new_experiment.getTrialManager().addTrial(new_trial);
-//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-//                        }
-//                    });
-//                } else if (type.equals("MEASUREMENT")) {
-//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-//                        @Override
-//                        public void onExperimentFetch(Experiment new_experiment) {
-//                            MeasurementTrial new_trial = new MeasurementTrial(user.getId(), location, date, Double.parseDouble(barcode.getTrialResult()), "UNIT");
-//                            new_experiment.getTrialManager().addTrial(new_trial);
-//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-//                        }
-//                    });
-//                }
             }
         });
 
     }
 
+    /**
+     * Adds a created trial to the experiment. Used as a common callback between all the create trial
+     * commands.
+     *
+     * @param trial      the trial to add
+     * @param experiment the experiment to add to
+     * @param listener   the listener callback to pass the result of the operation
+     */
     private void addTrialToExperiment(Trial trial, Experiment experiment, OnReadResultListener listener) {
         // if no trial was created, location error occurred
-        if (trial == null && experiment.getSettings().getGeoLocationRequired()) {
+        if (trial == null /*&& experiment.getSettings().getGeoLocationRequired()*/) {
             listener.onReadResult(Result.LOCATION_DENIED);
             return;
         }
@@ -413,6 +376,4 @@ public class BarcodeManager implements Serializable {
             listener.onReadResult(Result.EXPERIMENT_CLOSED);
         }
     }
-
-
 }

--- a/app/src/main/java/com/example/trialio/controllers/BarcodeManager.java
+++ b/app/src/main/java/com/example/trialio/controllers/BarcodeManager.java
@@ -1,5 +1,6 @@
 package com.example.trialio.controllers;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.media.Image;
 import android.util.Log;
@@ -15,7 +16,9 @@ import com.example.trialio.models.MeasurementTrial;
 import com.example.trialio.models.NonNegativeTrial;
 import com.example.trialio.models.Question;
 import com.example.trialio.models.Reply;
+import com.example.trialio.models.Trial;
 import com.example.trialio.models.User;
+import com.example.trialio.utils.ExperimentTypeUtility;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -49,14 +52,21 @@ public class BarcodeManager implements Serializable {
     private static final String USERS_PATH = "users";
     private static final String BARCODES_PATH = "barcodes";
 
-    /**
-     * Constructor for QuestionForumManager
-     */
-    public BarcodeManager(String userID) {
-        barcodeCollection = FirebaseFirestore.getInstance().collection(USERS_PATH).document(userID).collection(BARCODES_PATH);
+    public enum Result {
+        SUCCESS,
+        EXPERIMENT_CLOSED,
+        LOCATION_DENIED,
+        INVALID_EXPERIMENT,
+        UNREGISTERED_BARCODE
     }
 
 
+    /**
+     * Returns the status of the read to the invoker
+     */
+    public interface OnReadResultListener {
+        void onReadResult(Result result);
+    }
 
     /**
      * This interface represents an action to be taken when an Question document is fetched from the database.
@@ -70,7 +80,6 @@ public class BarcodeManager implements Serializable {
         void onBarcodeFetch(Barcode barcode);
     }
 
-
     /**
      * This interface represents an action to be taken when a collection of Questions is fetched
      * from the database.
@@ -82,6 +91,13 @@ public class BarcodeManager implements Serializable {
          * @param barcodes all the barcodes that were fetched from the database (belong to the current experiment)
          */
         void onManyBarcodesFetch(List<Barcode> barcodes);
+    }
+
+    /**
+     * Constructor for QuestionForumManager
+     */
+    public BarcodeManager(String userID) {
+        barcodeCollection = FirebaseFirestore.getInstance().collection(USERS_PATH).document(userID).collection(BARCODES_PATH);
     }
 
     public void createBarcode(Barcode newBarcode) {
@@ -148,11 +164,11 @@ public class BarcodeManager implements Serializable {
                     DocumentSnapshot doc = task.getResult();
                     if (doc.exists()) {
                         Barcode barcode = extractBarcodeDocument(doc);
-
-                        listener.onBarcodeFetch(barcode);
                         Log.d(TAG, "Barcode fetched successfully.");
+                        listener.onBarcodeFetch(barcode);
                     } else {
                         Log.d(TAG, "No barcode(s) found");
+                        listener.onBarcodeFetch(null);
                     }
                 } else {
                     Log.d(TAG, "Barcode fetch failed with " + task.getException());
@@ -264,61 +280,138 @@ public class BarcodeManager implements Serializable {
      * @param user
      */
     //input contains barcode info, use the info to fetch the document from firebase
-    public void readBarcode(String input, Location location, User user) {
-        this.setOnBarcodeFetchListener(input, new OnBarcodeFetchListener() {
+    public void readBarcode(Context context, String input, Location location, User user, OnReadResultListener listener) {
+        setOnBarcodeFetchListener(input, new OnBarcodeFetchListener() {
             @Override
             public void onBarcodeFetch(Barcode barcode) {
+                if (barcode == null) {
+                    // scanned barcode is not registered by the user
+                    listener.onReadResult(Result.UNREGISTERED_BARCODE);
+                    return;
+                }
                 Experiment experiment = barcode.getExperiment();
                 String type = barcode.getExperiment().getTrialManager().getType();
+
+                // fetch the experiment again from ExperimentManager to make sure it still exists
                 ExperimentManager experimentManager = new ExperimentManager();
-                Date date = new Date();
+                experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
+                    @Override
+                    public void onExperimentFetch(Experiment experiment) {
+                        // input validation: make sure experiment is valid
+                        if (experiment == null) {
+                            Log.w(TAG, "Experiment for QR code is not valid");
+                            listener.onReadResult(Result.INVALID_EXPERIMENT);
+                            return;
+                        }
 
-                if (type.equals("BINOMIAL")) {
-                    Log.d(TAG, "in Binomial");
-                    Log.d(TAG, experiment.getExperimentID());
-                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-                        @Override
-                        public void onExperimentFetch(Experiment new_experiment) {
-                            Log.d(TAG, new_experiment.getExperimentID());
-                            BinomialTrial new_trial = new BinomialTrial(user.getId(), location, date, Boolean.parseBoolean(barcode.getTrialResult()));
-                            Log.d(TAG, " Binomial trial created");
-                            new_experiment.getTrialManager().addTrial(new_trial);
-                            Log.d(TAG, " Binomial trial added");
+                        // determine if experiment is geolocation enabled
+                        boolean isLocationReq = experiment.getSettings().getGeoLocationRequired();
+                        CreateTrialCommand createCommand;
 
-                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
+                        if (type.equals(ExperimentTypeUtility.getBinomialType())) {
+                            // create a binomial trial
+                            boolean binomialRes = Boolean.parseBoolean(barcode.getTrialResult());
+                            createCommand = new CreateBinomialTrialCommand(
+                                    context, isLocationReq, binomialRes,
+                                    trial -> addTrialToExperiment(trial, experiment, listener)
+                            );
+
+                        } else if (type.equals(ExperimentTypeUtility.getCountType())) {
+                            // create a count trial
+                            createCommand = new CreateCountTrialCommand(
+                                    context, isLocationReq,
+                                    trial -> addTrialToExperiment(trial, experiment, listener)
+                            );
+                        } else if (type.equals(ExperimentTypeUtility.getNonNegativeType())) {
+                            // create a non-negative trial
+                            int nonNegRes = Integer.parseInt(barcode.getTrialResult());
+                            createCommand = new CreateNonNegativeTrialCommand(
+                                    context, isLocationReq, nonNegRes,
+                                    trial -> addTrialToExperiment(trial, experiment, listener)
+                            );
+                        } else if (type.equals(ExperimentTypeUtility.getMeasurementType())) {
+                            // create a measurement trial
+                            double measurementRes = Double.parseDouble(barcode.getTrialResult());
+                            createCommand = new CreateMeasurementTrialCommand(
+                                    context, isLocationReq, measurementRes,
+                                    trial -> addTrialToExperiment(trial, experiment, listener)
+                            );
+                        } else {
+                            // error
+                            throw new IllegalArgumentException("Invalid experiment type for scanned trial");
                         }
-                    });
-                } else if (type.equals("COUNT")) {
-                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-                        @Override
-                        public void onExperimentFetch(Experiment new_experiment) {
-                            CountTrial new_trial = new CountTrial(user.getId(), location, date);
-                            new_experiment.getTrialManager().addTrial(new_trial);
-                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-                        }
-                    });
-                } else if (type.equals("NONNEGATIVE")) {
-                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-                        @Override
-                        public void onExperimentFetch(Experiment new_experiment) {
-                            NonNegativeTrial new_trial = new NonNegativeTrial(user.getId(), location, date, Integer.parseInt(barcode.getTrialResult()));
-                            new_experiment.getTrialManager().addTrial(new_trial);
-                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-                        }
-                    });
-                } else if (type.equals("MEASUREMENT")) {
-                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
-                        @Override
-                        public void onExperimentFetch(Experiment new_experiment) {
-                            MeasurementTrial new_trial = new MeasurementTrial(user.getId(), location, date, Double.parseDouble(barcode.getTrialResult()), "UNIT");
-                            new_experiment.getTrialManager().addTrial(new_trial);
-                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
-                        }
-                    });
-                }
+
+                        createCommand.execute();
+
+                    }
+                });
+//
+//                Date date = new Date();
+//                if (type.equals("BINOMIAL")) {
+//                    Log.d(TAG, "in Binomial");
+//                    Log.d(TAG, experiment.getExperimentID());
+//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
+//                        @Override
+//                        public void onExperimentFetch(Experiment new_experiment) {
+//                            Log.d(TAG, new_experiment.getExperimentID());
+//                            BinomialTrial new_trial = new BinomialTrial(user.getId(), location, date, Boolean.parseBoolean(barcode.getTrialResult()));
+//                            Log.d(TAG, " Binomial trial created");
+//                            new_experiment.getTrialManager().addTrial(new_trial);
+//                            Log.d(TAG, " Binomial trial added");
+//
+//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
+//                        }
+//                    });
+//                } else if (type.equals("COUNT")) {
+//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
+//                        @Override
+//                        public void onExperimentFetch(Experiment new_experiment) {
+//                            CountTrial new_trial = new CountTrial(user.getId(), location, date);
+//                            new_experiment.getTrialManager().addTrial(new_trial);
+//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
+//                        }
+//                    });
+//                } else if (type.equals("NONNEGATIVE")) {
+//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
+//                        @Override
+//                        public void onExperimentFetch(Experiment new_experiment) {
+//                            NonNegativeTrial new_trial = new NonNegativeTrial(user.getId(), location, date, Integer.parseInt(barcode.getTrialResult()));
+//                            new_experiment.getTrialManager().addTrial(new_trial);
+//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
+//                        }
+//                    });
+//                } else if (type.equals("MEASUREMENT")) {
+//                    experimentManager.setOnExperimentFetchListener(experiment.getExperimentID(), new ExperimentManager.OnExperimentFetchListener() {
+//                        @Override
+//                        public void onExperimentFetch(Experiment new_experiment) {
+//                            MeasurementTrial new_trial = new MeasurementTrial(user.getId(), location, date, Double.parseDouble(barcode.getTrialResult()), "UNIT");
+//                            new_experiment.getTrialManager().addTrial(new_trial);
+//                            experimentManager.editExperiment(experiment.getExperimentID(), new_experiment);
+//                        }
+//                    });
+//                }
             }
         });
 
+    }
+
+    private void addTrialToExperiment(Trial trial, Experiment experiment, OnReadResultListener listener) {
+        // if no trial was created, location error occurred
+        if (trial == null && experiment.getSettings().getGeoLocationRequired()) {
+            listener.onReadResult(Result.LOCATION_DENIED);
+            return;
+        }
+
+        // add the created trial
+        ExperimentManager experimentManager = new ExperimentManager();
+        boolean addSuccess = experiment.getTrialManager().addTrial(trial);
+        experimentManager.editExperiment(experiment.getExperimentID(), experiment);
+
+        if (addSuccess) {
+            listener.onReadResult(Result.SUCCESS);
+        } else {
+            listener.onReadResult(Result.EXPERIMENT_CLOSED);
+        }
     }
 
 

--- a/app/src/main/java/com/example/trialio/controllers/CreateBinomialTrialCommand.java
+++ b/app/src/main/java/com/example/trialio/controllers/CreateBinomialTrialCommand.java
@@ -49,8 +49,8 @@ public class CreateBinomialTrialCommand extends CreateTrialCommand {
             });
         } else {
             // Failed to get Location
-            // TODO: do not upload trial, send message to UI
-            createTrialWithoutLocation(user);
+            // Signal that trial could not be created
+            listener.onResult(null);
         }
     }
 

--- a/app/src/main/java/com/example/trialio/controllers/CreateCountTrialCommand.java
+++ b/app/src/main/java/com/example/trialio/controllers/CreateCountTrialCommand.java
@@ -41,8 +41,8 @@ public class CreateCountTrialCommand extends CreateTrialCommand {
             });
         } else {
             // Failed to get Location
-            // TODO: do not upload trial, send message to UI
-            createTrialWithoutLocation(user);
+            // Signal that trial could not be created
+            listener.onResult(null);
         }
     }
 

--- a/app/src/main/java/com/example/trialio/controllers/CreateMeasurementTrialCommand.java
+++ b/app/src/main/java/com/example/trialio/controllers/CreateMeasurementTrialCommand.java
@@ -53,8 +53,8 @@ public class CreateMeasurementTrialCommand extends CreateTrialCommand {
             });
         } else {
             // Failed to get Location
-            // TODO: do not upload trial, send message to UI
-            createTrialWithoutLocation(user);
+            // Signal that trial could not be created
+            listener.onResult(null);
         }
     }
 

--- a/app/src/main/java/com/example/trialio/controllers/CreateNonNegativeTrialCommand.java
+++ b/app/src/main/java/com/example/trialio/controllers/CreateNonNegativeTrialCommand.java
@@ -46,8 +46,8 @@ public class CreateNonNegativeTrialCommand extends CreateTrialCommand {
             });
         } else {
             // Failed to get Location
-            // TODO: do not upload trial, send message to UI
-            createTrialWithoutLocation(user);
+            // Signal that trial could not be created
+            listener.onResult(null);
         }
     }
 

--- a/app/src/main/java/com/example/trialio/controllers/QRCodeGenerator.java
+++ b/app/src/main/java/com/example/trialio/controllers/QRCodeGenerator.java
@@ -14,13 +14,16 @@ import com.example.trialio.models.Experiment;
 import com.example.trialio.models.Location;
 import com.example.trialio.models.MeasurementTrial;
 import com.example.trialio.models.NonNegativeTrial;
+import com.example.trialio.models.Trial;
 import com.example.trialio.models.User;
+import com.example.trialio.utils.ExperimentTypeUtility;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 
 import java.util.Date;
+import java.util.function.LongFunction;
 
 import static android.graphics.Color.BLACK;
 import static android.graphics.Color.WHITE;
@@ -47,12 +50,19 @@ public class QRCodeGenerator extends AppCompatActivity {
     private static Context context;
 
 
-    public static Bitmap generateForTrial(Experiment experiment, String strResult, String information){
+    /**
+     * Generates a QR code for a given trial result
+     *
+     * @param experiment the experiment to encode
+     * @param strResult  the string result to encode
+     * @return the bitmap that represents the QR code
+     */
+    public static Bitmap generateForTrial(Experiment experiment, String strResult, String information) {
         String infoResult = "";
         Date date = new Date();
         BitMatrix result = null;
-        try{
-            infoResult = experiment.getTrialManager().getType() + "\n" +  strResult + "\n" +  experiment.getExperimentID();
+        try {
+            infoResult = experiment.getTrialManager().getType() + "\n" + strResult + "\n" + experiment.getExperimentID();
             result = new MultiFormatWriter().encode(infoResult, BarcodeFormat.QR_CODE, 300, 300, null);
         } catch (WriterException writerException) {
             writerException.printStackTrace();
@@ -62,106 +72,158 @@ public class QRCodeGenerator extends AppCompatActivity {
         int height = result.getHeight();
         int[] pixels = new int[width * height];
 
-        for (int x = 0; x < height; x ++){
+        for (int x = 0; x < height; x++) {
             int offset = x * width;
             for (int k = 0; k < width; k++) {
-                pixels[offset + k] = result.get(k,x) ? BLACK : WHITE;
+                pixels[offset + k] = result.get(k, x) ? BLACK : WHITE;
             }
         }
 
         Bitmap myBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        myBitmap.setPixels(pixels,0,width,0,0,width,height);
+        myBitmap.setPixels(pixels, 0, width, 0, 0, width, height);
         return myBitmap;
     }
 
+    // TODO: Callback for result of scan, enum to represent different statuses
 
     /**
      * readQR takes in the input that is encoded in the code then create a new trial with its info
-     * @param input 
+     *
+     * @param input
      * @param user
      */
-    public static void readQR(String[] input, Location location, User user){
-        if (input[0].equals("BINOMIAL")){
-            current_user = user;
-            Date date = new Date();
+    public static void readQR(Context context, String[] input, Location location, User user) {
+        // parse the raw input
+        String type = input[0];
+        String result = input[1];
+        String experimentId = input[2];
 
-            ExperimentManager experimentManager = new ExperimentManager();
-            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
-                @Override
-                public void onExperimentFetch(Experiment new_experiment) {
-                    if (new_experiment != null) {
-                        BinomialTrial new_trial = new BinomialTrial(current_user.getId(), location, date, Boolean.parseBoolean(input[1]));
-                        new_experiment.getTrialManager().addTrial(new_trial);
-                        experimentManager.editExperiment(input[2],new_experiment);
-                    } else {
-                        Log.e(TAG, "Failed to load experiments");
-                    }
+        // fetch experiment encoded in QR code
+        ExperimentManager experimentManager = new ExperimentManager();
+        experimentManager.setOnExperimentFetchListener(experimentId, new ExperimentManager.OnExperimentFetchListener() {
+            @Override
+            public void onExperimentFetch(Experiment experiment) {
+                // input validation: make sure experiment is valid
+                if (experiment == null) {
+                    Log.w(TAG, "Experiment for QR code is not valid");
+                    return;
                 }
-            });
 
-        } else if (input[0].equals("COUNT")){
-            current_user = user;
-            Date date = new Date();
+                // determine if experiment is geolocation enabled
+                boolean isLocationReq = experiment.getSettings().getGeoLocationRequired();
+                CreateTrialCommand createCommand;
 
+                if (type.equals(ExperimentTypeUtility.getBinomialType())) {
+                    // create a binomial trial
+                    boolean binomialRes = Boolean.parseBoolean(result);
+                    createCommand = new CreateBinomialTrialCommand(
+                            context, isLocationReq, binomialRes,
+                            trial -> addTrialToExperiment(trial, experiment)
+                    );
 
-            ExperimentManager experimentManager = new ExperimentManager();
-            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
-
-                @Override
-                public void onExperimentFetch(Experiment new_experiment) {
-                    if (new_experiment != null) {
-                        CountTrial new_trial = new CountTrial(current_user.getId(), location, date);
-                        new_experiment.getTrialManager().addTrial(new_trial);
-                        experimentManager.editExperiment(input[2],new_experiment);
-                    } else {
-                        Log.e(TAG, "Failed to load experiments");
-                    }
+                } else if (type.equals(ExperimentTypeUtility.getCountType())) {
+                    // create a count trial
+                    createCommand = new CreateCountTrialCommand(
+                            context, isLocationReq,
+                            trial -> addTrialToExperiment(trial, experiment)
+                    );
+                } else if (type.equals(ExperimentTypeUtility.getNonNegativeType())) {
+                    // create a non-negative trial
+                    int nonNegRes = Integer.parseInt(result);
+                    createCommand = new CreateNonNegativeTrialCommand(
+                            context, isLocationReq, nonNegRes,
+                            trial -> addTrialToExperiment(trial, experiment)
+                    );
+                } else if (type.equals(ExperimentTypeUtility.getMeasurementType())) {
+                    // create a measurement trial
+                    double measurementRes = Double.parseDouble(result);
+                    createCommand = new CreateMeasurementTrialCommand(
+                            context, isLocationReq, measurementRes,
+                            trial -> addTrialToExperiment(trial, experiment)
+                    );
+                } else {
+                    // error
+                    throw new IllegalArgumentException("Invalid experiment type for scanned trial");
                 }
-            });
-        } else if (input[0].equals("NONNEGATIVE")){
-            current_user = user;
-            Date date = new Date();
-            ExperimentManager experimentManager = new ExperimentManager();
-            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
-                @Override
-                public void onExperimentFetch(Experiment new_experiment) {
-                    if (new_experiment != null) {
-                        NonNegativeTrial new_trial = new NonNegativeTrial(current_user.getId(), location, date, Integer.parseInt(input[1]));
-                        new_experiment.getTrialManager().addTrial(new_trial);
-                        experimentManager.editExperiment(input[2],new_experiment);
-                    } else {
-                        Log.e(TAG, "Failed to load experiments");
-                    }
-                }
-            });
-        } else if (input[0].equals("MEASUREMENT")){
-            current_user = user;
-            Date date = new Date();
+
+                createCommand.execute();
+            }
+        });
 
 
-            ExperimentManager experimentManager = new ExperimentManager();
-            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
-                @Override
-                public void onExperimentFetch(Experiment new_experiment) {
-                    if (new_experiment != null) {
-                        MeasurementTrial new_trial = new MeasurementTrial(current_user.getId(), location, date, Double.parseDouble(input[1]), input[3]);
-                        new_experiment.getTrialManager().addTrial(new_trial);
-                        experimentManager.editExperiment(input[2],new_experiment);
-                    } else {
-                        Log.e(TAG, "Failed to load experiments");
-                    }
-                }
-            });
-        }
+//        if (input[0].equals("BINOMIAL")) {
+//            current_user = user;
+//            Date date = new Date();
+//
+//            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
+//                @Override
+//                public void onExperimentFetch(Experiment new_experiment) {
+//                    if (new_experiment != null) {
+//                        BinomialTrial new_trial = new BinomialTrial(current_user.getId(), location, date, Boolean.parseBoolean(input[1]));
+//                        new_experiment.getTrialManager().addTrial(new_trial);
+//                        experimentManager.editExperiment(input[2], new_experiment);
+//                    } else {
+//                        Log.e(TAG, "Failed to load experiments");
+//                    }
+//                }
+//            });
+//
+//        } else if (input[0].equals("COUNT")) {
+//            current_user = user;
+//            Date date = new Date();
+//
+//
+//            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
+//
+//                @Override
+//                public void onExperimentFetch(Experiment new_experiment) {
+//                    if (new_experiment != null) {
+//                        CountTrial new_trial = new CountTrial(current_user.getId(), location, date);
+//                        new_experiment.getTrialManager().addTrial(new_trial);
+//                        experimentManager.editExperiment(input[2], new_experiment);
+//                    } else {
+//                        Log.e(TAG, "Failed to load experiments");
+//                    }
+//                }
+//            });
+//        } else if (input[0].equals("NONNEGATIVE")) {
+//            current_user = user;
+//            Date date = new Date();
+//            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
+//                @Override
+//                public void onExperimentFetch(Experiment new_experiment) {
+//                    if (new_experiment != null) {
+//                        NonNegativeTrial new_trial = new NonNegativeTrial(current_user.getId(), location, date, Integer.parseInt(input[1]));
+//                        new_experiment.getTrialManager().addTrial(new_trial);
+//                        experimentManager.editExperiment(input[2], new_experiment);
+//                    } else {
+//                        Log.e(TAG, "Failed to load experiments");
+//                    }
+//                }
+//            });
+//        } else if (input[0].equals("MEASUREMENT")) {
+//            current_user = user;
+//            Date date = new Date();
+//
+//            experimentManager.setOnExperimentFetchListener(input[2], new ExperimentManager.OnExperimentFetchListener() {
+//                @Override
+//                public void onExperimentFetch(Experiment new_experiment) {
+//                    if (new_experiment != null) {
+//                        MeasurementTrial new_trial = new MeasurementTrial(current_user.getId(), location, date, Double.parseDouble(input[1]), input[3]);
+//                        new_experiment.getTrialManager().addTrial(new_trial);
+//                        experimentManager.editExperiment(input[2], new_experiment);
+//                    } else {
+//                        Log.e(TAG, "Failed to load experiments");
+//                    }
+//                }
+//            });
+//        }
 
     }
 
-
-
-
-
-
-
-
-
+    private static void addTrialToExperiment(Trial trial, Experiment experiment) {
+        ExperimentManager experimentManager = new ExperimentManager();
+        experiment.getTrialManager().addTrial(trial);
+        experimentManager.editExperiment(experiment.getExperimentID(), experiment);
+    }
 }

--- a/app/src/main/java/com/example/trialio/controllers/QRCodeGenerator.java
+++ b/app/src/main/java/com/example/trialio/controllers/QRCodeGenerator.java
@@ -102,8 +102,9 @@ public class QRCodeGenerator extends AppCompatActivity {
     /**
      * readQR takes in the input that is encoded in the code then create a new trial with its info
      *
-     * @param context the context in which the QR was scanned
-     * @param input   the raw input that was encoded in the QR code
+     * @param context  the context in which the QR was scanned
+     * @param input    the raw input that was encoded in the QR code
+     * @param listener the listener callback to pass the result of the read
      */
     public static void readQR(Context context, String[] input, OnReadResultListener listener) {
         // parse the raw input
@@ -165,9 +166,18 @@ public class QRCodeGenerator extends AppCompatActivity {
         });
     }
 
+
+    /**
+     * Adds a created trial to the experiment. Used as a common callback between all the create trial
+     * commands.
+     *
+     * @param trial      the trial to add
+     * @param experiment the experiment to add to
+     * @param listener   the listener callback to pass the result of the operation
+     */
     private static void addTrialToExperiment(Trial trial, Experiment experiment, OnReadResultListener listener) {
         // if no trial was created, location error occurred
-        if (trial == null && experiment.getSettings().getGeoLocationRequired()) {
+        if (trial == null /*&& experiment.getSettings().getGeoLocationRequired()*/) {
             listener.onReadResult(Result.LOCATION_DENIED);
             return;
         }


### PR DESCRIPTION
Changes made:
 - refactored BarcodeManager, QrCodeGenerator and ScanningActivity to use create trial command objects
 - added toast messages to inform the user whether their trial was added successfully or not
     - cases considered: add trial from QR normally (success), add QR when location necessary, add QR when location necessary but disabled, add QR trial when experiment closed, add QR trial when experiment no longer exists, 
     - all of the above cases also considered for barcodes. Barcodes have the additional check of scanning a barcode that has not been registered 

Note: observed that sometimes the scanner will get different inputs when scanning the same barcode. There isn't really much that we can do about this. I have already provided a helpful toast message to indicate the barcode was not recognized, which will make this unavoidable issue more user-friendly.

Closes #172 